### PR TITLE
Fix useToast listener setup

### DIFF
--- a/client/src/hooks/use-toast.js
+++ b/client/src/hooks/use-toast.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 const TOAST_LIMIT = 1;
 const TOAST_REMOVE_DELAY = 1000000;
@@ -124,7 +124,7 @@ function toast({ ...props }) {
 function useToast() {
   const [state, setState] = useState(memoryState);
 
-  useState(() => {
+  useEffect(() => {
     listeners.push(setState);
     return () => {
       const index = listeners.indexOf(setState);


### PR DESCRIPTION
## Summary
- register toast listeners via `useEffect`
- import `useEffect` in the hook

## Testing
- `npm run check` *(fails: Could not find declaration file for module '@/lib/utils')*

------
https://chatgpt.com/codex/tasks/task_e_6889e6baad9c832ab0207ddaf4713d9f