### PR TITLE
Ensure hover rect is always captured

### DIFF
--- a/client/src/components/PlantCell.jsx
+++ b/client/src/components/PlantCell.jsx
@@ -64,8 +64,8 @@ export default function PlantCell({ plant, index, isSelected, isHovered, onSelec
     }
   };
 
-  const handleMouseEnter = () => {
-    const rect = cellRef.current?.getBoundingClientRect();
+  const handleMouseEnter = (e) => {
+    const rect = e.currentTarget.getBoundingClientRect();
     onHover(plant, index, rect);
   };
 
@@ -73,9 +73,9 @@ export default function PlantCell({ plant, index, isSelected, isHovered, onSelec
     onHover(null);
   };
 
-  const handleHoverMouseMove = () => {
+  const handleHoverMouseMove = (e) => {
     if (!isHovered) return;
-    const rect = cellRef.current?.getBoundingClientRect();
+    const rect = e.currentTarget.getBoundingClientRect();
     onHover(plant, index, rect);
   };
 

--- a/client/src/components/PlantGrid.jsx
+++ b/client/src/components/PlantGrid.jsx
@@ -49,7 +49,18 @@ export default function PlantGrid() {
   const handleHover = (plant, index, rect) => {
     setHoveredPlant(plant);
     setHoveredIndex(plant ? (index ?? null) : null);
-    setHoveredRect(rect ?? null);
+
+    if (!plant) {
+      setHoveredRect(null);
+      return;
+    }
+
+    if (rect) {
+      setHoveredRect(rect);
+    } else {
+      const elem = document.querySelector(`[data-testid="plant-cell-${index}"]`);
+      setHoveredRect(elem ? elem.getBoundingClientRect() : null);
+    }
   };
 
   const clearSelection = () => {
@@ -101,7 +112,7 @@ export default function PlantGrid() {
                   isSelected={selectedPlants.some(p => p.id === plant.id)}
                   isHovered={hoveredPlant?.id === plant.id}
                   onSelect={handleSelect}
-                  onHover={(p, rect) => handleHover(p, index, rect)}
+                  onHover={(p, i, rect) => handleHover(p, i, rect)}
                   mousePositionRef={mousePositionRef}
                 />
               ))}


### PR DESCRIPTION
## Summary
- make PlantCell pass bounding client rect to onHover events
- update PlantGrid hover handler to recalc rect when absent

## Testing
- `npm run check` *(fails: Could not find declaration file for module '@/lib/utils')*

------
https://chatgpt.com/codex/tasks/task_e_688a3375a920832aa5bb4a36ad7faef9