### PR TITLE
Fix error overlay plugin usage

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 export default defineConfig({
   plugins: [
     react(),
-    runtimeErrorOverlay(),
+    ...(process.env.REPL_ID !== undefined ? [runtimeErrorOverlay()] : []),
     ...(process.env.NODE_ENV !== "production" &&
     process.env.REPL_ID !== undefined
       ? [


### PR DESCRIPTION
## Summary
- use the runtime error overlay plugin only when `REPL_ID` env var is set

## Testing
- `npm run check` *(fails: Could not find declaration file for module '@/lib/utils')*

------
https://chatgpt.com/codex/tasks/task_e_688a37544304832a8fff04e403b3bee7