### PR TITLE
Add motion layout to grid items

### DIFF
--- a/client/src/components/PlantCell.jsx
+++ b/client/src/components/PlantCell.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useMemo } from "react";
+import { motion } from "framer-motion";
 
 export default function PlantCell({ plant, index, isSelected, isHovered, onSelect, onHover, mousePositionRef }) {
   const cellRef = useRef(null);
@@ -94,7 +95,9 @@ export default function PlantCell({ plant, index, isSelected, isHovered, onSelec
   };
 
   return (
-    <div
+    <motion.div
+      layout
+      transition={{ layout: { type: 'spring', stiffness: 300, damping: 30 } }}
       ref={cellRef}
       className={`plant-cell flex flex-col items-center justify-center relative cursor-pointer transition-transform duration-100 ease-out ${
         isSelected ? 'opacity-100' : ''
@@ -111,6 +114,6 @@ export default function PlantCell({ plant, index, isSelected, isHovered, onSelec
         <div className="text-[8px] font-medium text-botanical-dark leading-tight">{plant.korean}</div>
         <div className="text-[6px] italic text-botanical-medium leading-tight mt-0.5">{plant.scientific}</div>
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/client/src/components/PlantGrid.jsx
+++ b/client/src/components/PlantGrid.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { motion } from "framer-motion";
 import { plantsData } from "../data/plantsData.js";
 import PlantCell from "./PlantCell.jsx";
 import SidePanel from "./SidePanel.jsx";
@@ -119,10 +120,16 @@ export default function PlantGrid() {
         }`}>
           <div className="max-w-4xl mx-auto">
             {/* Flexible Container allowing dynamic repositioning */}
-            <div className="flex flex-wrap justify-center gap-x-2 gap-y-4" data-testid="plant-grid" style={{
-              width: '100%',
-              maxWidth: '800px'
-            }}>
+            <motion.div
+              layout
+              transition={{ layout: { type: 'spring', stiffness: 300, damping: 30 } }}
+              className="flex flex-wrap justify-center gap-x-2 gap-y-4"
+              data-testid="plant-grid"
+              style={{
+                width: '100%',
+                maxWidth: '800px'
+              }}
+            >
               {plants.map((plant, index) => (
                 <PlantCell
                   key={plant.id}
@@ -135,7 +142,7 @@ export default function PlantGrid() {
                   mousePositionRef={mousePositionRef}
                 />
               ))}
-            </div>
+            </motion.div>
           </div>
         </main>
         


### PR DESCRIPTION
## Summary
- import `motion` from framer-motion
- wrap `PlantCell` root with `<motion.div>`
- wrap plant grid container with `<motion.div>` for smoother layout shifts

## Testing
- `npm run check` *(fails: Could not find declaration file for module '@/lib/utils' and others)*

------
https://chatgpt.com/codex/tasks/task_e_688a391d2354832a8ce5b28db3a9ff61