### PR TITLE
Fix nested anchor

### DIFF
--- a/client/src/pages/not-found.jsx
+++ b/client/src/pages/not-found.jsx
@@ -6,10 +6,11 @@ export default function NotFound() {
       <div className="text-center">
         <h1 className="text-4xl font-bold text-gray-900 mb-4">404</h1>
         <p className="text-gray-600 mb-6">페이지를 찾을 수 없습니다.</p>
-        <Link href="/">
-          <a className="text-botanical-accent hover:text-botanical-dark underline">
-            홈으로 돌아가기
-          </a>
+        <Link
+          href="/"
+          className="text-botanical-accent hover:text-botanical-dark underline"
+        >
+          홈으로 돌아가기
         </Link>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- avoid nested anchors in NotFound page

## Testing
- `npm run check` *(fails: could not find declaration files)*

------
https://chatgpt.com/codex/tasks/task_e_688a392ac580832a9f977a4a9a5e6647