### PR TITLE
Improve error logging

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -39,12 +39,17 @@ app.use((req, res, next) => {
 (async () => {
   const server = await registerRoutes(app);
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+  app.use((err: any, _req: Request, res: Response, next: NextFunction) => {
     const status = err.status || err.statusCode || 500;
     const message = err.message || "Internal Server Error";
 
     res.status(status).json({ message });
-    throw err;
+
+    // log the stack trace to help with debugging instead of crashing the server
+    log(err.stack || err.toString(), "error");
+
+    // propagate the error to any additional handlers if needed
+    next(err);
   });
 
   // importantly only setup vite in development and after


### PR DESCRIPTION
## Summary
- log error stack instead of throwing in Express error middleware
- forward the error to any additional handlers

## Testing
- `npm run check` *(fails: Could not find declaration file for several modules)*

------
https://chatgpt.com/codex/tasks/task_e_688a392bd64c832a8dd1074084e41856