### PR TITLE
Remove unused hoveredIndex state

### DIFF
--- a/client/src/components/PlantGrid.jsx
+++ b/client/src/components/PlantGrid.jsx
@@ -6,7 +6,6 @@ import SidePanel from "./SidePanel.jsx";
 export default function PlantGrid() {
   const [selectedPlants, setSelectedPlants] = useState([]);
   const [hoveredPlant, setHoveredPlant] = useState(null);
-  const [hoveredIndex, setHoveredIndex] = useState(null);
   const [hoveredRect, setHoveredRect] = useState(null);
   const [imageUrl, setImageUrl] = useState("");
   const mousePositionRef = useRef({ x: 0, y: 0 });
@@ -67,7 +66,6 @@ export default function PlantGrid() {
 
   const handleHover = (plant, index, rect) => {
     setHoveredPlant(plant);
-    setHoveredIndex(plant ? (index ?? null) : null);
 
     if (!plant) {
       setHoveredRect(null);


### PR DESCRIPTION
## Summary
- refactor PlantGrid to remove `hoveredIndex` state and setter

## Testing
- `npm run check` *(fails: could not find declaration files)*

------
https://chatgpt.com/codex/tasks/task_e_688a392d23ec832aa21c2548ad381b5b