### PR TITLE
Fix grid detail flicker with animated row

### DIFF
--- a/client/src/components/PlantGrid.jsx
+++ b/client/src/components/PlantGrid.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef } from "react";
-import { motion } from "framer-motion";
 import { plantsData } from "../data/plantsData.js";   // ← 경로 수정
 import PlantCell from "./PlantCell.jsx";
-import SidePanel from "./SidePanel.jsx";   
+import SidePanel from "./SidePanel.jsx";
+import { motion } from "framer-motion";
 export default function PlantGrid() {
   const [selectedPlants, setSelectedPlants] = useState([]);
   const [hoveredPlant, setHoveredPlant] = useState(null);
@@ -86,9 +86,7 @@ export default function PlantGrid() {
         {/* Main Grid */}
         <main className="py-12 px-6 w-full">
           <div className="max-w-4xl mx-auto">
-            <motion.div
-              layout
-              transition={{ layout: { type: "spring", stiffness: 100, damping: 60 } }}
+            <div
               className="flex flex-col items-center gap-y-4"
               data-testid="plant-grid"
               style={{ width: "100%", maxWidth: "680px" }}
@@ -115,27 +113,34 @@ export default function PlantGrid() {
                       ))}
                     </div>
 
-                    {containsHovered && (
-                      <div className="mt-2 p-4 border border-botanical-light bg-white text-xs">
-                        <div className="text-sm font-medium mb-1">
-                          {hoveredPlant.korean}{" "}
-                          <span className="italic text-botanical-medium">
-                            ({hoveredPlant.scientific})
-                          </span>
+                    <motion.div
+                      initial={false}
+                      animate={{ height: containsHovered ? "auto" : 0, opacity: containsHovered ? 1 : 0 }}
+                      transition={{ duration: 0.2 }}
+                      style={{ overflow: "hidden" }}
+                    >
+                      {containsHovered && (
+                        <div className="mt-2 p-4 border border-botanical-light bg-white text-xs">
+                          <div className="text-sm font-medium mb-1">
+                            {hoveredPlant.korean}{" "}
+                            <span className="italic text-botanical-medium">
+                              ({hoveredPlant.scientific})
+                            </span>
+                          </div>
+                          <div className="space-y-0.5">
+                            <div>생활형: {hoveredPlant.lifeForm}</div>
+                            <div>최대높이: {hoveredPlant.maxHeight} m</div>
+                            <div>근계 깊이: {hoveredPlant.rootDepth}</div>
+                            <div>광요구도: {hoveredPlant.lightNeed}/5</div>
+                            <div>수명: {hoveredPlant.lifespan} 년</div>
+                          </div>
                         </div>
-                        <div className="space-y-0.5">
-                          <div>생활형: {hoveredPlant.lifeForm}</div>
-                          <div>최대높이: {hoveredPlant.maxHeight} m</div>
-                          <div>근계 깊이: {hoveredPlant.rootDepth}</div>
-                          <div>광요구도: {hoveredPlant.lightNeed}/5</div>
-                          <div>수명: {hoveredPlant.lifespan} 년</div>
-                        </div>
-                      </div>
-                    )}
+                      )}
+                    </motion.div>
                   </div>
                 );
               })}
-            </motion.div>
+            </div>
           </div>
         </main>
 


### PR DESCRIPTION
## Summary
- add `framer-motion` again
- animate the row used for plant details instead of re-laying out the grid

## Testing
- `npm run check` *(fails: Could not find declaration file for module '@/lib/utils' and others)*

------
https://chatgpt.com/codex/tasks/task_e_688b0496a548832aac822f33b9a0e256