### PR TITLE
Fix grid shift when panel opens

### DIFF
--- a/client/src/components/PlantGrid.jsx
+++ b/client/src/components/PlantGrid.jsx
@@ -84,7 +84,11 @@ export default function PlantGrid() {
 
       <div className="flex">
         {/* Main Grid */}
-        <main className="py-12 px-6 w-full">
+        <main
+          className={`py-12 px-6 w-full transition-all duration-300 ${
+            selectedPlants.length > 0 ? 'mr-80' : ''
+          }`}
+        >
           <div className="max-w-4xl mx-auto">
             <div
               className="flex flex-col items-center gap-y-4"


### PR DESCRIPTION
## Summary
- add right margin to the main grid container so it moves left when the side panel is visible

## Testing
- `npm run check` *(fails: Could not find a declaration file for module '@/lib/utils', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688b0b599944832a9edcb53daf10730f