### PR TITLE
Improve grid responsiveness with side panel

### DIFF
--- a/client/src/components/PlantGrid.jsx
+++ b/client/src/components/PlantGrid.jsx
@@ -12,6 +12,9 @@ export default function PlantGrid() {
 
   const HOVER_OPEN_DELAY = 100;
   const HOVER_CLOSE_DELAY = 100;
+  const PANEL_WIDTH = 320; // Side panel width (w-80)
+  const CELL_TOTAL_WIDTH = 70; // Cell width including gap
+  const [columns, setColumns] = useState(10);
 
   // id 부여 + 데이터 전개 연산자 수정 (.data ➜ ...data)
   const plants = plantsData.map((data, index) => ({
@@ -57,6 +60,19 @@ export default function PlantGrid() {
     }
   };
 
+  const updateColumns = () => {
+    const availableWidth =
+      window.innerWidth - (selectedPlants.length > 0 ? PANEL_WIDTH : 0);
+    const maxCols = Math.floor(availableWidth / CELL_TOTAL_WIDTH);
+    setColumns(Math.max(1, Math.min(10, maxCols)));
+  };
+
+  useEffect(() => {
+    updateColumns();
+    window.addEventListener('resize', updateColumns);
+    return () => window.removeEventListener('resize', updateColumns);
+  }, [selectedPlants.length]);
+
   useEffect(() => {
     return () => {
       if (openTimeoutRef.current) clearTimeout(openTimeoutRef.current);
@@ -68,7 +84,13 @@ export default function PlantGrid() {
   return (
     <div className="font-crimson text-botanical-dark min-h-screen bg-white">
       {/* ───── Header ───── */}
-      <header className="py-8 px-6 border-b border-botanical-light text-center">
+      <header
+        className="py-8 px-6 border-b border-botanical-light text-center transition-all duration-300"
+        style={{
+          width: selectedPlants.length > 0 ? 'calc(100% - 20rem)' : '100%',
+          marginLeft: 'auto',
+        }}
+      >
         <h1 className="text-lg font-normal tracking-wide mb-2">식생 컬렉션</h1>
         <p className="text-xs text-botanical-medium font-light">
           Botanical Species Interactive Grid
@@ -85,18 +107,20 @@ export default function PlantGrid() {
       <div className="flex">
         {/* Main Grid */}
         <main
-          className={`py-12 px-6 w-full transition-all duration-300 ${
-            selectedPlants.length > 0 ? 'mr-80' : ''
-          }`}
+          className="py-12 px-6 transition-all duration-300"
+          style={{
+            width: selectedPlants.length > 0 ? 'calc(100% - 20rem)' : '100%',
+            marginLeft: 'auto',
+          }}
         >
           <div className="max-w-4xl mx-auto">
             <div
               className="flex flex-col items-center gap-y-4"
               data-testid="plant-grid"
-              style={{ width: "100%", maxWidth: "680px" }}
+              style={{ width: '100%', maxWidth: `${columns * CELL_TOTAL_WIDTH}px` }}
             >
-              {Array.from({ length: Math.ceil(plants.length / 10) }).map((_, rowIdx) => {
-                const rowPlants = plants.slice(rowIdx * 10, rowIdx * 10 + 10);
+              {Array.from({ length: Math.ceil(plants.length / columns) }).map((_, rowIdx) => {
+                const rowPlants = plants.slice(rowIdx * columns, rowIdx * columns + columns);
                 const containsHovered =
                   hoveredPlant && rowPlants.some((p) => p.id === hoveredPlant.id);
 
@@ -112,7 +136,7 @@ export default function PlantGrid() {
                         <PlantCell
                           key={plant.id}
                           plant={plant}
-                          index={rowIdx * 10 + idx}
+                          index={rowIdx * columns + idx}
                           isSelected={selectedPlants.some((p) => p.id === plant.id)}
                           isHovered={hoveredPlant?.id === plant.id}
                           onSelect={handleSelect}


### PR DESCRIPTION
## Summary
- update grid layout so main area and header shift when side panel is open
- compute column count based on available width
- ensure cells index uses dynamic column count

## Testing
- `npm run check` *(fails: Could not find declaration files)*

------
https://chatgpt.com/codex/tasks/task_e_688b13ab5f60832a92b31d2aa2fe6624