### PR TITLE
Fix Mac port listening error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Plant Grid Application
+
+This project visualizes plant data in an interactive grid using React and Express.
+
+## Prerequisites
+
+- **Node.js** version 20 or higher (can be installed via [nvm](https://github.com/nvm-sh/nvm) or Homebrew)
+- **npm** comes with Node.js
+- **VS Code** (optional but recommended)
+
+## Getting Started on macOS
+
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+2. **Start the development server**
+   ```bash
+   npm run dev
+   ```
+3. Open a browser and navigate to [http://localhost:5000](http://localhost:5000) to view the page.
+
+From VS Code you can open the integrated terminal (`Terminal` → `New Terminal`) and run the same commands.
+
+## Building for production
+
+To create a production build:
+
+```bash
+npm run build
+```
+
+The compiled files will be output to the `dist/` directory.

--- a/server/index.ts
+++ b/server/index.ts
@@ -69,7 +69,6 @@ app.use((req, res, next) => {
   server.listen({
     port,
     host: "0.0.0.0",
-    reusePort: true,
   }, () => {
     log(`serving on port ${port}`);
   });


### PR DESCRIPTION
## Summary
- remove unsupported `reusePort` option when starting the server

## Testing
- `npm run check` *(fails: Could not find a declaration file for module '@/lib/utils')*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_688b38e7dd44832a9b2efa0e92d3d5ec