### PR TITLE
feat: add layout API and run layout button

### DIFF
--- a/client/src/components/PlantGrid.jsx
+++ b/client/src/components/PlantGrid.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef } from "react";
 import plantsData from "../../../shared/plantsData.ts";
-import { runLayout } from "../api/runLayout.ts";
 import PlantCell from "./PlantCell.jsx";
 import SidePanel from "./SidePanel.jsx";
+import RunLayoutButton from "./RunLayoutButton.jsx";
 import { motion, AnimatePresence } from "framer-motion";
 export default function PlantGrid() {
   const [selectedPlants, setSelectedPlants] = useState([]);
@@ -82,16 +82,6 @@ export default function PlantGrid() {
   }, []);
   const clearSelection = () => setSelectedPlants([]);
 
-  const handleRunLayout = async () => {
-    try {
-      const inputs = selectedPlants.map(({ id, ...rest }) => rest);
-      const result = await runLayout(inputs);
-      console.log("Layout result", result);
-    } catch (err) {
-      console.error("Failed to run layout", err);
-    }
-  };
-
   return (
     <div className="font-crimson text-botanical-dark min-h-screen bg-white">
       {/* ───── Header ───── */}
@@ -114,12 +104,7 @@ export default function PlantGrid() {
           <span> / 100</span>
         </div>
         {selectedPlants.length > 0 && (
-          <button
-            onClick={handleRunLayout}
-            className="mt-2 px-2 py-1 border border-botanical-light text-xs"
-          >
-            Run Layout
-          </button>
+          <RunLayoutButton selectedPlants={selectedPlants} />
         )}
       </header>
 

--- a/client/src/components/RunLayoutButton.jsx
+++ b/client/src/components/RunLayoutButton.jsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { runLayout } from "../api/runLayout.ts";
+
+export default function RunLayoutButton({ selectedPlants }) {
+  const [result, setResult] = useState(null);
+
+  const handleClick = async () => {
+    try {
+      const inputs = selectedPlants.map(({ id, ...rest }) => rest);
+      const res = await runLayout(inputs);
+      setResult(res);
+      console.log("Layout result", res);
+    } catch (err) {
+      console.error("Failed to run layout", err);
+    }
+  };
+
+  if (selectedPlants.length === 0) return null;
+
+  return (
+    <div>
+      <button
+        onClick={handleClick}
+        className="mt-2 px-2 py-1 border border-botanical-light text-xs"
+      >
+        Run Layout
+      </button>
+      {result && (
+        <pre className="mt-2 p-2 text-xs border border-botanical-light bg-white overflow-x-auto">
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Express route that invokes `python -m plant_layout.main` to generate layouts and clean up temporary data
- serialize selected plants to CSV for Python layout inputs
- add `runLayout` API helper and `RunLayoutButton` component to trigger the layout and display results

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688dcf212338832a8fb24eb3facd8f4e