### PR TITLE
Integrate plant layout engine and shared data

### DIFF
--- a/client/src/lib/utils.js
+++ b/client/src/lib/utils.js
@@ -1,6 +1,0 @@
-import { clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs) {
-  return twMerge(clsx(inputs));
-}

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,0 +1,7 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+// Merge Tailwind classes with conditional className handling
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/server/utils/serialize.ts
+++ b/server/utils/serialize.ts
@@ -1,4 +1,5 @@
-import type { PlantInput } from "../shared/schema";
+// Import shared schema so both client and server use the same typing
+import type { PlantInput } from "../../shared/schema";
 
 const headers = [
   "scientific_name",


### PR DESCRIPTION
## Summary
- Use shared `PlantInput` schema and dataset for both client and server
- Serialize selected plants to CSV and add `/api/run-layout` endpoint calling Python layout engine
- Port client utilities to TypeScript for consistent builds

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_688dd846b51c832aae4b253c2a23c9f1