### PR TITLE
Integrate VLA invocation into layout endpoint

### DIFF
--- a/plant_layout/main.py
+++ b/plant_layout/main.py
@@ -15,6 +15,7 @@ def main():
     placements = []
     with open(args.csv_path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
+        fieldnames = list(reader.fieldnames or [])
         for i, row in enumerate(reader):
             placements.append({
                 **row,
@@ -23,9 +24,18 @@ def main():
             })
 
     os.makedirs(args.out_dir, exist_ok=True)
-    out_path = os.path.join(args.out_dir, "placement.json")
-    with open(out_path, "w", encoding="utf-8") as f:
+
+    # existing JSON output for debugging/compatibility
+    json_path = os.path.join(args.out_dir, "placement.json")
+    with open(json_path, "w", encoding="utf-8") as f:
         json.dump(placements, f)
+
+    # VLA expects a CSV file describing the layout
+    vla_path = os.path.join(args.out_dir, "layout.csv")
+    with open(vla_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames + ["x", "y"])
+        writer.writeheader()
+        writer.writerows(placements)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- write VLA-compatible CSV output alongside existing JSON in `plant_layout/main.py`
- update `/api/run-layout` route to call VLA with generated CSV and return a simple status

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`
- `curl -s -X POST http://localhost:4000/api/run-layout [...]` with sample plant data
- inspected `/tmp/server.log` to confirm VLA (simulated with `cat`) processed the CSV

------
https://chatgpt.com/codex/tasks/task_e_688de35b946c832aa1be23b80ab3ce68