### PR TITLE
Expose layout API and configure Hangul font

### DIFF
--- a/plant_layout/__init__.py
+++ b/plant_layout/__init__.py
@@ -1,0 +1,18 @@
+import os
+
+# Configure Matplotlib to display Hangul characters if available.
+try:  # pragma: no cover - font configuration best effort
+    import matplotlib
+    from matplotlib import font_manager
+
+    font_path = os.environ.get(
+        "HANGUL_FONT_PATH", "/usr/share/fonts/truetype/nanum/NanumGothic.ttf"
+    )
+    if os.path.exists(font_path):
+        font_manager.fontManager.addfont(font_path)
+        font_name = font_manager.FontProperties(fname=font_path).get_name()
+        matplotlib.rcParams["font.family"] = font_name
+        matplotlib.rcParams["axes.unicode_minus"] = False
+except Exception:
+    # Matplotlib might not be installed or the font missing; ignore in that case.
+    pass


### PR DESCRIPTION
## Summary
- expose `/api/run-layout` that executes the Python layout engine, converting selected plants to CSV and invoking the CLI with a configurable `PYTHON` path
- share plant data across client and server and seed in-memory storage
- configure Matplotlib to load a Hangul font so generated images render Korean text correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ef75ef780832aad1064b055ccba68