### PR TITLE
feat: save VLA output for inspection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+Output/*
+!Output/.gitkeep

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -114,6 +114,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.status(500).json({ message: "Failed to run layout" });
     } finally {
       if (dir) {
+        const outputRoot = join(process.cwd(), "Output");
+        try {
+          await fs.mkdir(outputRoot, { recursive: true });
+          const runDir = join(outputRoot, Date.now().toString());
+          await fs.cp(dir, runDir, { recursive: true });
+        } catch (copyErr) {
+          console.error(copyErr);
+        }
         await fs.rm(dir, { recursive: true, force: true });
       }
     }


### PR DESCRIPTION
## Summary
- copy temporary layout outputs into `Output` folder under project root
- ignore output artifacts in git

## Testing
- `npm test` (fails: Missing script)
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_688efb487d3c832aaba28d5e0deb542d