### PR TITLE
Hide Run Layout result output

### DIFF
--- a/client/src/components/RunLayoutButton.jsx
+++ b/client/src/components/RunLayoutButton.jsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { runLayout } from "../api/runLayout.ts";
 
 export default function RunLayoutButton({ selectedPlants }) {
-  const [result, setResult] = useState(null);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(false);
 
@@ -11,9 +10,7 @@ export default function RunLayoutButton({ selectedPlants }) {
       setLoading(true);
       setError(null);
       const inputs = selectedPlants.map(({ id, ...rest }) => rest);
-      const res = await runLayout(inputs);
-      setResult(res);
-      console.log("Layout result", res);
+      await runLayout(inputs);
     } catch (err) {
       console.error("Failed to run layout", err);
       setError("Failed to run layout");
@@ -35,11 +32,6 @@ export default function RunLayoutButton({ selectedPlants }) {
       </button>
       {error && (
         <div className="mt-2 text-xs text-red-600">{error}</div>
-      )}
-      {result && (
-        <pre className="mt-2 p-2 text-xs border border-botanical-light bg-white overflow-x-auto">
-          {JSON.stringify(result, null, 2)}
-        </pre>
       )}
     </div>
   );

--- a/client/src/components/RunLayoutButton.test.jsx
+++ b/client/src/components/RunLayoutButton.test.jsx
@@ -14,14 +14,16 @@ describe("RunLayoutButton", () => {
     vi.clearAllMocks();
   });
 
-  it("shows result after successful run", async () => {
-    runLayout.mockResolvedValue({ success: true });
-    render(<RunLayoutButton selectedPlants={[{ id: 1, name: "A" }]} />);
-    fireEvent.click(screen.getByRole("button", { name: /run layout/i }));
-    expect(screen.getByRole("button", { name: /running/i })).toBeDisabled();
-    await screen.findByText(/success/);
-    expect(screen.queryByText(/failed to run layout/i)).not.toBeInTheDocument();
-  });
+    it("runs without displaying result", async () => {
+      runLayout.mockResolvedValue({ success: true });
+      render(<RunLayoutButton selectedPlants={[{ id: 1, name: "A" }]} />);
+      fireEvent.click(screen.getByRole("button", { name: /run layout/i }));
+      expect(screen.getByRole("button", { name: /running/i })).toBeDisabled();
+      await screen.findByRole("button", { name: /run layout/i });
+      expect(runLayout).toHaveBeenCalled();
+      expect(screen.queryByText(/failed to run layout/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/success/)).not.toBeInTheDocument();
+    });
 
   it("shows error message when run fails", async () => {
     runLayout.mockRejectedValue(new Error("bad"));


### PR DESCRIPTION
## Summary
- don't render run layout response in the UI
- adjust tests to reflect removed result output

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f0dace2f4832aa6d04bf9c62da904