### PR TITLE
feat: save VLA output for inspection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+Output/*
+!Output/.gitkeep


### PR DESCRIPTION
## Summary
- copy temporary layout outputs into `Output` folder under project root
- ignore output artifacts in git
- log when VLA runs and whether it finishes successfully

## Testing
- `npm test` (fails: Missing script)
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_688efb487d3c832aaba28d5e0deb542d