### PR TITLE
Fix VLA invocation by adding width and height parameters

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -91,9 +91,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       const vla = process.env.VLA;
       if (vla) {
-        console.log(`Running VLA: ${vla} ${layoutPath}`);
+        console.log(`Running VLA: ${vla} ${width} ${height} ${layoutPath}`);
         await new Promise<void>((resolve, reject) => {
-          const proc = spawn(vla, [layoutPath]);
+          const proc = spawn(vla, [String(width), String(height), layoutPath]);
 
           proc.stdout.on("data", (d: Buffer) => {
             console.log(d.toString());


### PR DESCRIPTION
## Summary
- ensure width and height arguments are passed when calling VLA to run layouts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890511b77d8832a9dd14b87cea5ad6e