### PR TITLE
Fix VLA invocation and expose layout outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",
-    "test": "vitest run --environment jsdom --globals"
+    "test": "vitest run --environment jsdom --globals",
+    "list-output": "tsx scripts/list-latest-output.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/scripts/list-latest-output.ts
+++ b/scripts/list-latest-output.ts
@@ -1,0 +1,34 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+
+async function main() {
+  const outputRoot = join(process.cwd(), 'Output');
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.readdir(outputRoot, { withFileTypes: true });
+  } catch {
+    console.log('No Output directory found');
+    return;
+  }
+
+  const dirs = entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+
+  if (dirs.length === 0) {
+    console.log('No layout outputs found');
+    return;
+  }
+
+  const latest = dirs[dirs.length - 1];
+  const latestPath = join(outputRoot, latest);
+  console.log(`Latest output directory: ${latestPath}`);
+
+  const files = await fs.readdir(latestPath);
+  for (const file of files) {
+    console.log(` - ${file}`);
+  }
+}
+
+main();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -91,9 +91,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       const vla = process.env.VLA;
       if (vla) {
-        console.log(`Running VLA: ${vla} ${layoutPath}`);
+        console.log(`Running VLA: ${vla} ${width} ${height} ${layoutPath}`);
         await new Promise<void>((resolve, reject) => {
-          const proc = spawn(vla, [layoutPath]);
+          const proc = spawn(
+            vla,
+            [String(width), String(height), layoutPath],
+            { cwd: dir },
+          );
 
           proc.stdout.on("data", (d: Buffer) => {
             console.log(d.toString());


### PR DESCRIPTION
## Summary
- ensure VLA runs in its temp folder so generated files are copied to the server `Output` directory
- add `list-output` script to show the most recent layout results

## Testing
- `npm test`
- `npm run list-output`


------
https://chatgpt.com/codex/tasks/task_e_6890511b77d8832a9dd14b87cea5ad6e