### PR TITLE
Ensure VLA runs in request temp directory

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -93,7 +93,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (vla) {
         console.log(`Running VLA: ${vla} ${width} ${height} ${layoutPath}`);
         await new Promise<void>((resolve, reject) => {
-          const proc = spawn(vla, [String(width), String(height), layoutPath]);
+          const proc = spawn(vla, [String(width), String(height), layoutPath], {
+            cwd: dir,
+          });
 
           proc.stdout.on("data", (d: Buffer) => {
             console.log(d.toString());


### PR DESCRIPTION
## Summary
- run VLA inside per-request temporary directory
- confirm temp dir is recursively copied to timestamped Output folder

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6890581bc75c832aa6b91745d1b3ba1c