### PR TITLE
chore: add helper to persist VLA env

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",
-    "test": "vitest run --environment jsdom --globals"
+    "test": "vitest run --environment jsdom --globals",
+    "setup:vla": "bash scripts/configure-vla.sh"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/scripts/configure-vla.sh
+++ b/scripts/configure-vla.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Adds the VLA environment variable to the user's shell profile so it
+# persists across terminal sessions. Optionally accepts a custom path
+# as the first argument.
+
+set -e
+
+VLA_PATH="${1:-/Users/kse/Documents/GitHub/VLA/dist/test}"
+PROFILE="${HOME}/.${SHELL##*/}rc"
+LINE="export VLA=\"${VLA_PATH}\""
+
+if [ -f "$PROFILE" ]; then
+  if grep -Fxq "$LINE" "$PROFILE"; then
+    echo "VLA environment variable already configured in $PROFILE"
+  else
+    echo "$LINE" >> "$PROFILE"
+    echo "Added VLA environment variable to $PROFILE"
+  fi
+else
+  echo "$LINE" > "$PROFILE"
+  echo "Created $PROFILE and added VLA environment variable"
+fi
+


### PR DESCRIPTION
## Summary
- add `configure-vla.sh` script to append VLA env variable to shell profile
- expose `setup:vla` npm script for running the helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689059a2ffa8832aa0f2692fb4efeeda