### PR TITLE
chore: export VLA when script is sourced

### DIFF
--- a/scripts/configure-vla.sh
+++ b/scripts/configure-vla.sh
@@ -21,3 +21,12 @@ else
   echo "Created $PROFILE and added VLA environment variable"
 fi
 
+# If the script is sourced, export VLA for the current shell session so
+# it can be used immediately without restarting the terminal.
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+  export VLA="${VLA_PATH}"
+  echo "Exported VLA environment variable for current shell"
+else
+  echo "VLA environment variable will be available in new sessions"
+fi
+


### PR DESCRIPTION
## Summary
- export `VLA` in `configure-vla.sh` when sourced so it's immediately available
- print a message when the variable will only be available in new sessions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68905ef72d54832abc74ee446d4ed40a