### PR TITLE
fix: ensure VLA helper script is sourced

### DIFF
--- a/scripts/configure-vla.sh
+++ b/scripts/configure-vla.sh
@@ -7,17 +7,34 @@ set -e
 
 VLA_PATH="${1:-/Users/kse/Documents/GitHub/VLA/dist/test}"
 PROFILE="${HOME}/.${SHELL##*/}rc"
-LINE="export VLA=\"${VLA_PATH}\""
+SET_SCRIPT="${HOME}/set_vla.sh"
+EXPORT_LINE="export VLA=\"${VLA_PATH}\""
+SOURCE_LINE="source \"${SET_SCRIPT}\""
 
-if [ -f "$PROFILE" ]; then
-  if grep -Fxq "$LINE" "$PROFILE"; then
-    echo "VLA environment variable already configured in $PROFILE"
+# Write export line to helper script to be sourced each session.
+echo "${EXPORT_LINE}" > "${SET_SCRIPT}"
+chmod +x "${SET_SCRIPT}"
+echo "Created ${SET_SCRIPT}"
+
+# Ensure profile sources the helper script.
+if [ -f "${PROFILE}" ]; then
+  if grep -Fxq "${SOURCE_LINE}" "${PROFILE}"; then
+    echo "Profile already sources ${SET_SCRIPT}"
   else
-    echo "$LINE" >> "$PROFILE"
-    echo "Added VLA environment variable to $PROFILE"
+    echo "${SOURCE_LINE}" >> "${PROFILE}"
+    echo "Added source line to ${PROFILE}"
   fi
 else
-  echo "$LINE" > "$PROFILE"
-  echo "Created $PROFILE and added VLA environment variable"
+  echo "${SOURCE_LINE}" > "${PROFILE}"
+  echo "Created ${PROFILE} and added source line"
+fi
+
+# If the script is sourced, export VLA for the current shell session so
+# it can be used immediately without restarting the terminal.
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+  export VLA="${VLA_PATH}"
+  echo "Exported VLA environment variable for current shell"
+else
+  echo "VLA environment variable will be available in new sessions"
 fi
 


### PR DESCRIPTION
## Summary
- create `~/set_vla.sh` with the `VLA` export and source it from the user's shell profile
- export `VLA` immediately when `configure-vla.sh` is sourced

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68905ef72d54832abc74ee446d4ed40a